### PR TITLE
Update discord-notify.yml - this should work

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -9,15 +9,14 @@ jobs:
   notify:
     runs-on: ubuntu-latest
 
-    # コミットメッセージに「アウトプット」または「成果」が含まれているか
-    if: >-
-      ${{ github.event.head_commit.message && (
-        contains(github.event.head_commit.message, 'アウトプット') ||
-        contains(github.event.head_commit.message, '成果')
-      ) }}
-
     steps:
+      # コミットメッセージに「アウトプット」または「成果」が含まれているか
       - name: Notify Discord
+        if: >-
+          ${{ github.event.head_commit.message && (
+            contains(github.event.head_commit.message, 'アウトプット') ||
+            contains(github.event.head_commit.message, '成果')
+          ) }}
         run: |
           COMMIT_MSG="${{ github.event.head_commit.message }}"
           echo "✅ 条件に一致したコミットを検出しました: $COMMIT_MSG"


### PR DESCRIPTION
フォークして自分のほうで動き確認して動くように修正しました。
これで `if` に引っかかれないものでも Actions にエラー出ないようになりました。

エラーが出る原因：
 - 定義されたアクションを実行した結果、`name` の前に `false` 出力されることで、アクション全体が failed したと勘違い判断をしたため
 - 確認箇所：
https://github.com/kanbep2017/JavaAllProject/actions/runs/16549321380/job/46801961322
 ```
 Error: Process completed with exit code 1.
 ```

解決策：
 - `if` を `name` の中に入れて実行自体は成功したと判断させる
 - `name` の中の `run` アクションは実際に実行されずに終わるが、`name` 全体としてはエラーなく終了したという判断がされる